### PR TITLE
Poprawki async + lista dla całego miesiąca + wszystkie

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,17 @@ curl "https://pniedzwiedzinski.github.io/kalendarz-swiat-nietypowych/{miesiąc}/
 
 # Przykład dla 1. marca
 curl "https://pniedzwiedzinski.github.io/kalendarz-swiat-nietypowych/3/1.json"
+
+# Przykład dla lutego (cały miesiąc)
+curl "https://pniedzwiedzinski.github.io/kalendarz-swiat-nietypowych/2.json"
+
+# Przykład dla wszystkich świąt (cały rok)
+curl "https://pniedzwiedzinski.github.io/kalendarz-swiat-nietypowych/all.json"
 ```
 
 ## Response
 
+> Notka: W przypadku braku świąt tablica będzie pusta.
 ``` json
 [
     {

--- a/generateApi.js
+++ b/generateApi.js
@@ -6,16 +6,10 @@ const YEAR = new Date().getFullYear();
 const main = async () => {
   try {
     const list = await fetchCalendar(YEAR);
-    generateApi(list);
+    await generateApi(list);
   } catch (e) {
     console.error('Error during generating.');
     console.error(e);
-  }
-};
-
-const mkdir = (dir) => {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir);
   }
 };
 
@@ -24,19 +18,33 @@ const days = Array.from(Array(32).keys());
 months.shift();
 days.shift();
 
-const generateApi = (list) => {
+const generateApi = async (list) => {
   const dir = './dist';
-  mkdir(dir);
-  console.log(months);
-  months.forEach((month) => {
-    mkdir(`${dir}/${month}`);
-    days.forEach((day) => {
-      holidays = list.filter(
-        (holiday) => holiday.month === month && holiday.day === day
+  await fs.ensureDir(dir);
+
+  const monthPromises = months.map(async month => {
+    await fs.ensureDir(`${dir}/${month}`);
+
+    const dayPromises = days.map(async day => {
+      const holidays = list.filter(
+          (holiday) => holiday.month === month && holiday.day === day
       );
-      fs.writeFile(`${dir}/${month}/${day}.json`, JSON.stringify(holidays));
+      await fs.writeFile(`${dir}/${month}/${day}.json`, JSON.stringify(holidays));
     });
+
+    dayPromises.push((async () => {
+      const holidays = list.filter(
+          (holiday) => holiday.month === month
+      );
+      await fs.writeFile(`${dir}/${month}.json`, JSON.stringify(holidays));
+    })());
+
+    return Promise.all([dayPromises]);
   });
+
+  monthPromises.push(fs.writeFile(`${dir}/all.json`, JSON.stringify(list)));
+
+  return Promise.all([monthPromises]);
 };
 
 main();


### PR DESCRIPTION
Wyrzuciłem z kodu wszystkie synchroniczne wywołania (mkdir)
Dorzuciłem awaity i ogólne "upromisowienie", gdzie to było potrzebne (bo `catch` nie łapie błędów zapisu do pliku w bieżącej wersji)
Do tego dodałem też generowanie plików dla całego miesiąca (wywołanie przez `/{miesiac}.json`) i całego roku (`/all.json`).
Zaktualizowałem też README o nowe przykłady